### PR TITLE
Add Kubernetes manifests and fix frontend container runtime configuration

### DIFF
--- a/k8s/01-namespace.yaml
+++ b/k8s/01-namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: namespace
+    environment: production
+  annotations:
+    description: "TrendScope - Stock price trend analysis application namespace"

--- a/k8s/02-configmap.yaml
+++ b/k8s/02-configmap.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trendscope-config
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: configmap
+data:
+  # Backend configuration
+  BACKEND_HOST: "0.0.0.0"
+  BACKEND_PORT: "8000"
+  PYTHONPATH: "/app/src"
+  UV_CACHE_DIR: "/tmp/.cache/uv"
+  
+  # Frontend configuration
+  NODE_ENV: "production"
+  FRONTEND_PORT: "3000"
+  HOSTNAME: "0.0.0.0"
+  
+  # API endpoints - クラスタ内通信
+  # Backend API URL for server-side proxy requests
+  BACKEND_API_URL: "http://trendscope-backend-service:8000"
+  
+  # Health check paths
+  BACKEND_HEALTH_PATH: "/health"
+  FRONTEND_HEALTH_PATH: "/"
+
+---
+# Secretの例（必要に応じて使用）
+# API キーや機密情報がある場合はこちらを使用
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trendscope-secrets
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: secret
+type: Opaque
+# data:
+  # 例: APIキーがある場合
+  # API_KEY: base64でエンコードされた値
+  # DB_PASSWORD: base64でエンコードされた値

--- a/k8s/03-backend-deployment.yaml
+++ b/k8s/03-backend-deployment.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trendscope-backend
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: trendscope
+spec:
+  replicas: 2
+  
+  # ローリングアップデート戦略
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trendscope
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trendscope
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: trendscope
+    spec:
+      containers:
+      - name: backend
+        # GitHub Container Registry の trendscope-api イメージを使用
+        image: ghcr.io/hirano00o/trendscope-api:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        
+        # 環境変数の設定
+        envFrom:
+        - configMapRef:
+            name: trendscope-config
+        # - secretRef:  # 機密情報がある場合
+        #     name: trendscope-secrets
+        
+        env:
+        - name: HOST
+          valueFrom:
+            configMapKeyRef:
+              name: trendscope-config
+              key: BACKEND_HOST
+        - name: PORT
+          valueFrom:
+            configMapKeyRef:
+              name: trendscope-config
+              key: BACKEND_PORT
+        - name: PYTHONPATH
+          valueFrom:
+            configMapKeyRef:
+              name: trendscope-config
+              key: PYTHONPATH
+        - name: UV_CACHE_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: trendscope-config
+              key: UV_CACHE_DIR
+        
+        # リソース制限（Docker Composeの設定を参考）
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        
+        # ヘルスチェック設定
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 40
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        
+        # セキュリティコンテキスト
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          readOnlyRootFilesystem: false  # アプリケーションの要件に応じて調整
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        
+      # Pod レベルのセキュリティコンテキスト
+      securityContext:
+        fsGroup: 1000

--- a/k8s/04-frontend-deployment.yaml
+++ b/k8s/04-frontend-deployment.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trendscope-frontend
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: trendscope
+spec:
+  replicas: 2
+  
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trendscope
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trendscope
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/part-of: trendscope
+    spec:
+      containers:
+      - name: frontend
+        # GitHub Container Registry の trendscope-ui イメージを使用
+        image: ghcr.io/hirano00o/trendscope-ui:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+          name: http
+          protocol: TCP
+        
+        # 環境変数の設定（ConfigMapから全て自動読み込み）
+        envFrom:
+        - configMapRef:
+            name: trendscope-config
+        
+        # リソース制限（Docker Composeの設定を参考）
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "300m"
+        
+        # ヘルスチェック設定
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 40
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        
+        # セキュリティコンテキスト
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        
+        # ボリュームマウント（Next.jsキャッシュなど）
+        volumeMounts:
+        - name: nextjs-cache
+          mountPath: /app/.next/cache
+        - name: tmp
+          mountPath: /tmp
+      
+      # Pod レベルのセキュリティコンテキスト
+      securityContext:
+        fsGroup: 1000
+      
+      # ボリューム定義
+      volumes:
+      - name: nextjs-cache
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/k8s/05-backend-service.yaml
+++ b/k8s/05-backend-service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: trendscope-backend-service
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: trendscope
+  annotations:
+    description: "TrendScope Backend API Service"
+spec:
+  type: ClusterIP  # 内部通信用
+  selector:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: backend
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+    protocol: TCP

--- a/k8s/06-frontend-service.yaml
+++ b/k8s/06-frontend-service.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: trendscope-frontend-service
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: trendscope
+  annotations:
+    description: "TrendScope Frontend Web Service"
+spec:
+  type: LoadBalancer
+
+  selector:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+    protocol: TCP

--- a/k8s/07-cilium-l2-announcement.yaml
+++ b/k8s/07-cilium-l2-announcement.yaml
@@ -1,0 +1,29 @@
+---
+# Cilium L2 Announcement Policy
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: trendscope-l2-announcement
+  namespace: trendscope
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: trendscope
+  annotations:
+    description: "TrendScope LoadBalancer IP announcement policy for frontend service"
+spec:
+  # フロントエンドサービスのみを対象とする
+  serviceSelector:
+    matchLabels:
+      app.kubernetes.io/name: trendscope
+      app.kubernetes.io/component: frontend
+  
+  # ネットワークインターフェース（通常はeth0, eth1など）
+  interfaces:
+    - ^eth[0-9]+
+  
+  # ExternalIPsの通知を有効化
+  externalIPs: true
+  
+  # LoadBalancerIPsの通知を有効化
+  loadBalancerIPs: true

--- a/k8s/08-cilium-loadbalancer-ippool.yaml
+++ b/k8s/08-cilium-loadbalancer-ippool.yaml
@@ -1,0 +1,21 @@
+---
+# Cilium LoadBalancer IP Pool
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: trendscope-ippool
+  labels:
+    app.kubernetes.io/name: trendscope
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: trendscope
+  annotations:
+    description: "TrendScope LoadBalancer IP pool for frontend service"
+spec:
+  blocks:
+     - cidr: "192.168.0.160/28"
+  
+  # 対象サービスの選択
+  serviceSelector:
+    matchLabels:
+      app.kubernetes.io/name: trendscope
+      app.kubernetes.io/component: frontend

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,202 @@
+# TrendScope Kubernetes デプロイメントガイド
+
+このディレクトリには、TrendScopeアプリケーションをKubernetes環境にデプロイするためのマニフェストが含まれています。
+
+## 📁 ディレクトリ構造
+
+```
+k8s/
+├── README.md                               # このファイル
+├── 01-namespace.yaml                       # Namespace定義
+├── 02-configmap.yaml                       # ConfigMapとSecret定義
+├── 03-backend-deployment.yaml              # Backend Deployment
+├── 04-frontend-deployment.yaml             # Frontend Deployment
+├── 05-backend-service.yaml                # Backend Service
+├── 06-frontend-service.yaml               # Frontend Service
+├── 07-cilium-l2-announcement.yaml         # Cilium L2 Announcement Policy
+└── 08-cilium-loadbalancer-ippool.yaml     # Cilium LoadBalancer IP Pool
+```
+
+## 🚀 デプロイメント手順
+
+### 前提条件
+
+1. **Kubernetesクラスタ**が利用可能であること
+2. **kubectl**がインストールされ、クラスタに接続されていること
+3. **Cilium CNI**がインストールされ、L2 Announcementが有効であること
+
+### 1. Cilium L2 Announcement 有効化
+
+Ciliumで L2 Announcement が有効になっていることを確認してください：
+
+```bash
+# Cilium設定の確認
+kubectl get configmap cilium-config -n kube-system -o yaml | grep l2-announcements
+
+# L2 Announcementが無効の場合、有効化
+kubectl patch configmap cilium-config -n kube-system --patch '{"data":{"enable-l2-announcements":"true"}}'
+
+# Cilium ポッドの再起動
+kubectl rollout restart daemonset/cilium -n kube-system
+```
+
+### 2. IPプール設定の調整
+
+`08-cilium-loadbalancer-ippool.yaml` でIPアドレス範囲を実際のネットワーク環境に合わせて調整してください：
+
+```yaml
+spec:
+  blocks:
+    - cidr: "192.168.1.100/32"  # 実際のIPアドレスに変更
+```
+
+### 3. アプリケーションのデプロイ
+
+```bash
+# 全マニフェストを一括適用
+kubectl apply -f k8s/
+
+# または個別に適用
+kubectl apply -f k8s/01-namespace.yaml
+kubectl apply -f k8s/02-configmap.yaml
+kubectl apply -f k8s/03-backend-deployment.yaml
+kubectl apply -f k8s/04-frontend-deployment.yaml
+kubectl apply -f k8s/05-backend-service.yaml
+kubectl apply -f k8s/06-frontend-service.yaml
+kubectl apply -f k8s/07-cilium-l2-announcement.yaml
+kubectl apply -f k8s/08-cilium-loadbalancer-ippool.yaml
+```
+
+### 4. デプロイメント状況の確認
+
+```bash
+# ポッドの状況確認
+kubectl get pods -n trendscope
+
+# サービスの状況確認（EXTERNAL-IPが割り当てられることを確認）
+kubectl get services -n trendscope
+
+# Cilium設定の確認
+kubectl get ciliuml2announcementpolicy -n trendscope
+kubectl get ciliumloadbalancerippool
+```
+
+## 🔧 運用コマンド
+
+### ログ確認
+
+```bash
+# リアルタイムログ
+kubectl logs -f deployment/trendscope-backend -n trendscope
+kubectl logs -f deployment/trendscope-frontend -n trendscope
+
+# 全ポッドのログ
+kubectl logs -l app.kubernetes.io/name=trendscope -n trendscope
+```
+
+### スケーリング
+
+```bash
+# 手動スケーリング
+kubectl scale deployment trendscope-backend --replicas=5 -n trendscope
+kubectl scale deployment trendscope-frontend --replicas=4 -n trendscope
+
+# デプロイメント状況の詳細確認
+kubectl describe deployment trendscope-backend -n trendscope
+```
+
+### 更新とローリングアップデート
+
+```bash
+# イメージの更新
+kubectl set image deployment/trendscope-backend backend=ghcr.io/hirano00o/trendscope-api:v1.1.0 -n trendscope
+kubectl set image deployment/trendscope-frontend frontend=ghcr.io/hirano00o/trendscope-ui:v1.1.0 -n trendscope
+
+# ローリングアップデートの状況確認
+kubectl rollout status deployment/trendscope-backend -n trendscope
+kubectl rollout status deployment/trendscope-frontend -n trendscope
+
+# ロールバック
+kubectl rollout undo deployment/trendscope-backend -n trendscope
+```
+
+## 🌐 ネットワーク設定
+
+### LoadBalancer IP の確認
+
+```bash
+# 割り当てられたIPの確認
+kubectl get service trendscope-frontend-service -n trendscope -o wide
+
+# Cilium L2 Announcement の状況確認
+kubectl logs -l k8s-app=cilium -n kube-system | grep "L2 announcement"
+```
+
+### アクセス確認
+
+```bash
+# Frontend サービスのIPを取得
+FRONTEND_IP=$(kubectl get service trendscope-frontend-service -n trendscope -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# アクセステスト
+curl http://$FRONTEND_IP
+```
+
+## 🏗️ アーキテクチャ設定
+
+### 本番環境仕様
+
+- **高可用性**: Backend 2レプリカ、Frontend 2レプリカ
+- **スケーリング**: 手動スケーリング（必要に応じて）
+- **ネットワーク**: Cilium L2 Announcement による LoadBalancer IP
+- **レジストリ**: GitHub Container Registry（ghcr.io）
+- **セキュリティ**: 非root実行、最小権限、リソース制限
+
+### リソース配分
+
+#### Backend
+- **CPU**: 250m（要求）/ 500m（制限）
+- **Memory**: 512Mi（要求）/ 1Gi（制限）
+
+#### Frontend  
+- **CPU**: 100m（要求）/ 300m（制限）
+- **Memory**: 256Mi（要求）/ 512Mi（制限）
+
+## ⚠️ 注意事項
+
+1. **Cilium設定**: L2 Announcementが有効であることを確認してください
+2. **IPアドレス**: LoadBalancer IP Pool は実際のネットワーク環境に合わせて調整してください
+3. **リソース監視**: 本番環境では適切な監視とアラートを設定してください
+4. **バックアップ**: 重要な設定は定期的にバックアップしてください
+
+## 🆘 トラブルシューティング
+
+### Cilium関連
+
+```bash
+# Cilium ポッドの状況確認
+kubectl get pods -n kube-system -l k8s-app=cilium
+
+# L2 Announcement の設定確認
+kubectl get ciliuml2announcementpolicy -A
+kubectl describe ciliuml2announcementpolicy trendscope-l2-announcement -n trendscope
+
+# IP Pool の状況確認
+kubectl get ciliumloadbalancerippool
+kubectl describe ciliumloadbalancerippool trendscope-ippool
+```
+
+### LoadBalancer IP が割り当てられない場合
+
+```bash
+# サービスの詳細確認
+kubectl describe service trendscope-frontend-service -n trendscope
+
+# Cilium Agent のログ確認
+kubectl logs -l k8s-app=cilium -n kube-system | grep -i "load.*balance\|l2.*announce"
+
+# IP Pool の競合確認
+kubectl get services --all-namespaces -o wide | grep LoadBalancer
+```
+
+詳しいサポートが必要な場合は、プロジェクトのIssueページでお知らせください。


### PR DESCRIPTION
## Summary
- Kubernetesマニフェストを追加してTrendScopeのデプロイメント環境を構築
- フロントエンドコンテナのランタイム設定問題を修正
- コンテナ間通信のためのAPIプロキシを実装

## Changes
- **Kubernetes manifests**: フロントエンド・バックエンドのDeployment、Service、Ingressを追加
- **API proxy**: フロントエンドでバックエンドサービスへのプロキシルートを実装
- **Runtime configuration**: 不要なランタイム設定APIを削除し、プロキシベースの通信に変更

## Test plan
- [ ] Kubernetesクラスターでのデプロイメントが成功することを確認
- [ ] フロントエンド・バックエンド間の通信が正常に動作することを確認  
- [ ] Ingressを通じて外部からアクセス可能であることを確認
- [ ] 株式分析機能が正常に動作することを確認