### PR TITLE
Fix Discord Bot cron schedule display to respect CRON_SCHEDULE env var

### DIFF
--- a/discord-bot/cmd/discord-bot/main.go
+++ b/discord-bot/cmd/discord-bot/main.go
@@ -258,26 +258,18 @@ func createAnalysisRequests(stocks []*csv.Stock) []api.AnalysisRequest {
 
 // getNextExecutionTime calculates the next execution time based on cron schedule
 //
-// @description Cron式に基づいて次回実行時刻を計算する
-// 表示用の概算時刻を返す
+// @description 設定されたCron式に基づいて次回実行時刻を計算する
+// scheduler.GetNextExecutionTime関数を使用して正確な次回実行時刻を計算
 //
 // @returns {string} 次回実行予定時刻の文字列
 func (app *App) getNextExecutionTime() string {
-	// Simple calculation for "0 10 * * 1-5" (weekdays at 10:00)
-	now := time.Now()
-
-	// If it's a weekday and before 10 AM, next execution is today at 10 AM
-	if now.Weekday() >= time.Monday && now.Weekday() <= time.Friday && now.Hour() < 10 {
-		return time.Date(now.Year(), now.Month(), now.Day(), 10, 0, 0, 0, now.Location()).Format("2006-01-02 15:04:05")
+	nextTime, err := scheduler.GetNextExecutionTime(app.config.CronSchedule)
+	if err != nil {
+		log.Printf("Failed to calculate next execution time: %v", err)
+		return "Unknown (invalid cron expression)"
 	}
-
-	// Otherwise, next execution is next Monday at 10 AM
-	daysUntilMonday := (7 - int(now.Weekday()) + int(time.Monday)) % 7
-	if daysUntilMonday == 0 {
-		daysUntilMonday = 7
-	}
-	nextMonday := now.AddDate(0, 0, daysUntilMonday)
-	return time.Date(nextMonday.Year(), nextMonday.Month(), nextMonday.Day(), 10, 0, 0, 0, nextMonday.Location()).Format("2006-01-02 15:04:05")
+	
+	return nextTime.Format("2006-01-02 15:04:05")
 }
 
 // shutdown gracefully shuts down the application


### PR DESCRIPTION
## Summary
- Discord Botのcron設定が正しく表示されるよう修正
- CRON_SCHEDULE環境変数で設定した任意の時刻が正確に表示される
- 従来はハードコードされた「平日10時」のみ表示されていた問題を解決

## Changes
- **scheduler package**: `GetNextExecutionTime()` 関数を新規実装
- **main.go**: ハードコードされた時刻計算を削除し、scheduler関数を使用
- **Error handling**: 無効なcron式に対する適切なエラー処理を追加
- **Documentation**: 包括的なドキュメンテーションと使用例を追加

## Test plan
- [x] ビルドテスト成功確認
- [x] 複数のcron式での動作テスト実行
- [x] エラーハンドリングの動作確認
- [x] 既存機能への影響がないことを確認

## Before/After
**Before**: どのCRON_SCHEDULEを設定しても「平日10時」と表示
**After**: 設定されたcron式に基づく正確な次回実行時刻を表示

例:
- `CRON_SCHEDULE="30 14 * * *"` → 毎日14時30分と表示  
- `CRON_SCHEDULE="0 9 * * 1"` → 毎週月曜9時と表示