### PR TITLE
Improve Discord notification message format

### DIFF
--- a/discord-bot/cmd/discord-bot/main.go
+++ b/discord-bot/cmd/discord-bot/main.go
@@ -268,7 +268,7 @@ func (app *App) getNextExecutionTime() string {
 		log.Printf("Failed to calculate next execution time: %v", err)
 		return "Unknown (invalid cron expression)"
 	}
-	
+
 	return nextTime.Format("2006-01-02 15:04:05")
 }
 

--- a/discord-bot/pkg/scheduler/cron.go
+++ b/discord-bot/pkg/scheduler/cron.go
@@ -368,11 +368,14 @@ func (s *Scheduler) JobCount() int {
 // @example
 // ```go
 // nextTime, err := GetNextExecutionTime("0 10 * * 1-5")
-// if err != nil {
-//     log.Printf("Error: %v", err)
-// } else {
-//     log.Printf("Next execution: %s", nextTime.Format("2006-01-02 15:04:05"))
-// }
+//
+//	if err != nil {
+//	    log.Printf("Error: %v", err)
+//	} else {
+//
+//	    log.Printf("Next execution: %s", nextTime.Format("2006-01-02 15:04:05"))
+//	}
+//
 // ```
 func GetNextExecutionTime(cronExpr string) (time.Time, error) {
 	// Create a temporary scheduler for validation
@@ -393,7 +396,7 @@ func GetNextExecutionTime(cronExpr string) (time.Time, error) {
 // calculateNextExecution calculates the next execution time from current time
 //
 // @description 現在時刻から次回実行時刻を計算する内部関数
-// 
+//
 // @param {[]string} cronParts パース済みのCron式の各部分
 // @param {time.Time} from 計算の基準時刻
 // @returns {time.Time} 次回実行予定時刻
@@ -426,7 +429,7 @@ func (s *Scheduler) calculateNextExecution(cronParts []string, from time.Time) (
 //
 // @param {time.Time} t チェック対象の時刻
 // @param {string} minute 分の指定
-// @param {string} hour 時の指定  
+// @param {string} hour 時の指定
 // @param {string} day 日の指定
 // @param {string} month 月の指定
 // @param {string} weekday 曜日の指定
@@ -481,6 +484,6 @@ func (s *Scheduler) matchesNumericValue(spec string, value int) bool {
 	}
 
 	// TODO: Add support for ranges (e.g., "10-15") and lists (e.g., "10,12,14") if needed
-	
+
 	return false
 }


### PR DESCRIPTION
## Summary
- Change Discord notification from markdown table format to individual company format
- Display each company as bold heading with symbol in parentheses  
- Add sub-header with confidence (5 decimal places), score (5 decimal places), and 3 service links
- Include links to Kabutan, Yahoo Finance Japan, and Trendscope analysis

## Changes Made
### Before (Table Format)
```
| シンボル | 企業名 | 信頼度 | スコア |
|---------|--------|--------|--------|
| 7203.T | [トヨタ自動車](https://kabutan.jp/stock/?code=7203) | 0.800 | 0.750 |
```

### After (Individual Company Format)
```
**トヨタ自動車(7203.T)**
-# 信頼度: 0.80000, スコア: 0.75000, [株探](https://kabutan.jp/stock/?code=7203), [Yahoo](https://finance.yahoo.co.jp/quote/7203.T/bbs), [trendscope](https://trendscope.hirano00o.dev/analysis/7203.T)
```

## Implementation Details
- Modified `createAnalysisEmbed` function in `discord-bot/pkg/discord/webhook.go`
- Enhanced URL generation for 3 services:
  - Kabutan: `https://kabutan.jp/stock/?code={stockCode}` (without .T suffix)
  - Yahoo Finance Japan: `https://finance.yahoo.co.jp/quote/{symbol}/bbs` 
  - Trendscope: `https://trendscope.hirano00o.dev/analysis/{symbol}`
- Updated precision from 3 to 5 decimal places for confidence and score values

## Test Plan
- [x] Code compiles successfully
- [x] Go formatting applied
- [x] Message format matches requirements
- [ ] Test with actual Discord webhook (manual verification needed)