### PR TITLE
Fix exchange identifier mapping based on market segment

### DIFF
--- a/stock-db-batch/src/stock_batch/services/stock_fetcher.py
+++ b/stock-db-batch/src/stock_batch/services/stock_fetcher.py
@@ -72,7 +72,8 @@ class StockFetcher:
     """
 
     # 日本株シンボルの正規表現パターン
-    JAPAN_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{3,4}\.T$")
+    # 対応取引所: .T(東京), .S(札幌), .F(福岡), .N(名古屋), .OS(大阪)
+    JAPAN_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{3,4}\.(T|S|F|N|OS)$")
 
     def __init__(self, max_retries: int = 3, retry_delay: float = 1.0) -> None:
         """StockFetcher を初期化する
@@ -250,7 +251,8 @@ class StockFetcher:
     def is_valid_symbol(self, symbol: str) -> bool:
         """株式シンボルの形式を検証する
 
-        日本株の形式（XXXX.T）かチェックする。
+        日本株の形式かチェックする。
+        対応する取引所識別子: .T(東京), .S(札幌), .F(福岡), .N(名古屋), .OS(大阪)
 
         Args:
             symbol: 検証する株式シンボル
@@ -261,6 +263,8 @@ class StockFetcher:
         Example:
             >>> fetcher = StockFetcher()
             >>> fetcher.is_valid_symbol("1332.T")
+            True
+            >>> fetcher.is_valid_symbol("3698.S")
             True
             >>> fetcher.is_valid_symbol("INVALID")
             False

--- a/stock-db-batch/tests/test_models_company.py
+++ b/stock-db-batch/tests/test_models_company.py
@@ -126,6 +126,84 @@ class TestCSVCompanyData:
         symbol = csv_data.to_yfinance_symbol()
         assert symbol == "130A.T"
 
+    def test_csv_to_symbol_conversion_sapporo_market(self) -> None:
+        """札幌証券取引所のシンボル変換テスト（XXXX → XXXX.S）"""
+        csv_data = CSVCompanyData(
+            code="3698",
+            name="CRI・ミドルウェア",
+            market="札P",
+            current_value="1220.0",
+            change_percent="-0.49%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "3698.S"
+
+    def test_csv_to_symbol_conversion_nagoya_market(self) -> None:
+        """名古屋証券取引所のシンボル変換テスト（XXXX → XXXX.N）"""
+        csv_data = CSVCompanyData(
+            code="2200",
+            name="テスト名証企業",
+            market="名P",
+            current_value="500.0",
+            change_percent="+1.2%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "2200.N"
+
+    def test_csv_to_symbol_conversion_fukuoka_market(self) -> None:
+        """福岡証券取引所のシンボル変換テスト（XXXX → XXXX.F）"""
+        csv_data = CSVCompanyData(
+            code="8885",
+            name="テスト福証企業",
+            market="福P",
+            current_value="750.0",
+            change_percent="-2.1%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "8885.F"
+
+    def test_csv_to_symbol_conversion_osaka_market(self) -> None:
+        """大阪証券取引所のシンボル変換テスト（XXXX → XXXX.OS）"""
+        csv_data = CSVCompanyData(
+            code="9999",
+            name="テスト大証企業",
+            market="大P",
+            current_value="300.0",
+            change_percent="+0.5%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "9999.OS"
+
+    def test_csv_to_symbol_conversion_unknown_market(self) -> None:
+        """未知の市場区分でのデフォルト変換テスト（XXXX → XXXX.T）"""
+        csv_data = CSVCompanyData(
+            code="1234",
+            name="未知の市場企業",
+            market="未知",
+            current_value="100.0",
+            change_percent="0%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "1234.T"  # デフォルトは東京証券取引所
+
+    def test_csv_to_symbol_conversion_empty_market(self) -> None:
+        """空の市場区分でのデフォルト変換テスト（XXXX → XXXX.T）"""
+        csv_data = CSVCompanyData(
+            code="1234",
+            name="市場未指定企業",
+            market="",
+            current_value="100.0",
+            change_percent="0%",
+        )
+
+        symbol = csv_data.to_yfinance_symbol()
+        assert symbol == "1234.T"  # デフォルトは東京証券取引所
+
     def test_csv_parse_current_price_float(self) -> None:
         """現在値の浮動小数点変換テスト"""
         csv_data = CSVCompanyData(

--- a/stock-db-batch/tests/test_services_stock_fetcher.py
+++ b/stock-db-batch/tests/test_services_stock_fetcher.py
@@ -207,16 +207,23 @@ class TestStockFetcher:
         """株式シンボル形式検証のテスト"""
         fetcher = StockFetcher()
 
-        # 有効な日本株シンボル
+        # 有効な日本株シンボル（東京証券取引所）
         assert fetcher.is_valid_symbol("1332.T") is True
         assert fetcher.is_valid_symbol("130A.T") is True
         assert fetcher.is_valid_symbol("9999.T") is True
+        
+        # 有効な日本株シンボル（その他の取引所）
+        assert fetcher.is_valid_symbol("3698.S") is True  # 札幌証券取引所
+        assert fetcher.is_valid_symbol("2200.N") is True  # 名古屋証券取引所
+        assert fetcher.is_valid_symbol("8885.F") is True  # 福岡証券取引所
+        assert fetcher.is_valid_symbol("9999.OS") is True  # 大阪証券取引所
 
         # 無効なシンボル
         assert fetcher.is_valid_symbol("") is False
-        assert fetcher.is_valid_symbol("1332") is False  # .Tがない
+        assert fetcher.is_valid_symbol("1332") is False  # 取引所識別子がない
         assert fetcher.is_valid_symbol("INVALID") is False
         assert fetcher.is_valid_symbol("1332.T.") is False  # 余分な文字
+        assert fetcher.is_valid_symbol("1332.X") is False  # 無効な取引所識別子
 
     def test_get_fetcher_stats(self) -> None:
         """フェッチャー統計情報取得のテスト"""


### PR DESCRIPTION
市場区分の1文字目に基づいて取引所識別子を正しく変換するよう修正。
従来は一律「.T」を付与していたが、以下のマッピングに変更:

- 札 → .S (札幌証券取引所)
- 東 → .T (東京証券取引所)
- 福 → .F (福岡証券取引所)
- 名 → .N (名古屋証券取引所)
- 大 → .OS (大阪証券取引所)
- その他/空 → .T (デフォルト: 東京証券取引所)

Changes:
- Add EXCHANGE_MAPPING to CSVCompanyData class
- Update to_yfinance_symbol() method with market-based mapping
- Extend StockFetcher regex pattern to support all exchanges
- Add comprehensive test cases for all market segments
- Add error handling for unknown/empty market segments

Testing:
- All existing tests pass
- New test cases added for each exchange
- Symbol validation updated to support new identifiers