### PR TITLE
googletrans 4.0非同期API対応でstock-db-batch翻訳エラーを修正

### DIFF
--- a/stock-db-batch/main.py
+++ b/stock-db-batch/main.py
@@ -4,13 +4,14 @@ TrendScope 株式データバッチ処理アプリケーション
 エントリーポイント
 """
 
+import asyncio
 import logging
 import sys
 
 from stock_batch.main_batch_application import BatchConfig, MainBatchApplication
 
 
-def main() -> int:
+async def main() -> int:
     """メイン実行関数
 
     Returns:
@@ -22,7 +23,7 @@ def main() -> int:
 
         # アプリケーション実行
         app = MainBatchApplication(config)
-        result = app.run_batch()
+        result = await app.run_batch()
 
         if result.success:
             print(f"バッチ処理成功: {result.total_processed}件処理")
@@ -37,4 +38,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(asyncio.run(main()))

--- a/stock-db-batch/src/stock_batch/main_batch_application.py
+++ b/stock-db-batch/src/stock_batch/main_batch_application.py
@@ -200,7 +200,7 @@ class MainBatchApplication:
         except Exception as e:
             logger.warning("Liveness Probe状態マーカー削除失敗: %s", e)
 
-    def run_batch(self) -> BatchResult:
+    async def run_batch(self) -> BatchResult:
         """バッチ処理を実行する
 
         全てのサービスを統合してエンドツーエンドの処理を実行する。
@@ -253,7 +253,7 @@ class MainBatchApplication:
 
             # 3. 翻訳処理（オプション）
             if self.config.enable_translation:
-                csv_companies = self._translate_business_summaries(
+                csv_companies = await self._translate_business_summaries(
                     csv_companies, result
                 )
 
@@ -378,7 +378,7 @@ class MainBatchApplication:
         logger.info("株価データ取得完了: %d件処理", len(enriched_companies))
         return enriched_companies
 
-    def _translate_business_summaries(
+    async def _translate_business_summaries(
         self, companies: list, result: BatchResult
     ) -> list:
         """ビジネス要約を翻訳する
@@ -403,8 +403,10 @@ class MainBatchApplication:
 
             try:
                 if company.business_summary:
-                    translated_summary = translation_service.translate_to_japanese(
-                        company.business_summary
+                    translated_summary = (
+                        await translation_service.translate_to_japanese(
+                            company.business_summary
+                        )
                     )
                     company.business_summary = translated_summary
 


### PR DESCRIPTION
## 概要
- googletrans 4.0の非同期API変更による翻訳エラーを修正
- 翻訳サービスとメインバッチ処理を非同期パターンに変換
- 非同期翻訳機能のテストスイート更新

## 問題
googletrans 4.0で`translate()`メソッドがコルーチンを返すように変更され、awaitが必要になりました。既存の同期コードでは以下のエラーが発生していました：
```
'coroutine' object has no attribute 'text'
RuntimeWarning: coroutine 'Translator.translate' was never awaited
```

## 解決策
- **TranslationService**: `async with Translator()`パターンを使用した非同期メソッドに変換
- **メイン処理**: `run_batch()`と翻訳処理を非同期化
- **エントリーポイント**: main.pyで`asyncio.run()`を使用
- **テスト**: `@pytest.mark.asyncio`と`AsyncMock`を使用したテストに移行

## 変更内容
- `translation.py`: `translate_to_japanese()`と`translate_multiple_texts()`を非同期化
- `main_batch_application.py`: `run_batch()`と`_translate_business_summaries()`を非同期化
- `main.py`: `asyncio.run()`を使用した非同期エントリーポイント
- `test_services_translation.py`: 適切なモックを使用した非同期テストケース

## テスト計画
- [x] 非同期モックを使用した翻訳サービス単体テストが成功
- [x] コードフォーマット・リント検査(ruff)適用済み
- [x] メイン翻訳機能の動作確認

## 期待される効果
stock-db-batchの処理パイプラインで発生していた翻訳失敗を解決します。