### PR TITLE
httpxのHTTP 200 OKログを抑制

### DIFF
--- a/stock-db-batch/src/stock_batch/main_batch_application.py
+++ b/stock-db-batch/src/stock_batch/main_batch_application.py
@@ -513,6 +513,10 @@ class MainBatchApplication:
         stock_batch_logger = logging.getLogger("stock_batch")
         stock_batch_logger.setLevel(log_level)
 
+        # httpxのログレベルをWARNINGに設定してHTTP 200 OKログを抑制
+        httpx_logger = logging.getLogger("httpx")
+        httpx_logger.setLevel(logging.WARNING)
+
     def _setup_yfinance_cache(self) -> None:
         """yfinanceキャッシュ設定を行う
 


### PR DESCRIPTION
## 概要
stock-db-batchでgoogletransが大量のHTTP 200 OKログを出力する問題を解決しました。

## 変更内容
- `main_batch_application.py`の`_setup_logging()`メソッドでhttpxライブラリのログレベルをWARNINGに設定
- 翻訳API成功時の大量ログ出力を抑制

## 問題
googletransライブラリが内部的に使用するhttpxが、Google翻訳APIへのリクエスト成功時に以下のようなINFOレベルログを大量出力していました：

```
2025-09-01 14:25:12 - httpx - INFO - HTTP Request: GET https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ja&... "HTTP/2 200 OK"
```

## 解決策
httpxのログレベルをWARNINGに設定することで：
- ✅ HTTP 200 OK成功ログを抑制
- ✅ エラーログ（4xx, 5xx）は引き続き表示
- ✅ デバッグに必要な情報は維持

## テスト計画
- [ ] バッチ処理実行時のログ出力量確認
- [ ] エラー時のログが適切に出力されることを確認